### PR TITLE
closes #21 - Internally use IQueryable<TEntity> instead of contexts

### DIFF
--- a/src/SimpleSoft.Database.EFCore/EFCoreExistsByExternalId.cs
+++ b/src/SimpleSoft.Database.EFCore/EFCoreExistsByExternalId.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -14,22 +15,20 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity, IHaveExternalId<TId>
         where TId : IEquatable<TId>
     {
-        private readonly EFCoreContextContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreExistsByExternalId(
-            EFCoreContextContainer container
-        )
+        /// <param name="query"></param>
+        public EFCoreExistsByExternalId(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
         public async Task<bool> ExistsAsync(TId externalId, CancellationToken ct) =>
-            await _container.Query<TEntity>().AnyAsync(e => e.ExternalId.Equals(externalId), ct);
+            await _query.AnyAsync(e => e.ExternalId.Equals(externalId), ct);
     }
 
     /// <summary>
@@ -43,8 +42,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreExistsByExternalId(EFCoreContextContainer container) : base(container)
+        /// <param name="query"></param>
+        public EFCoreExistsByExternalId(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.EFCore/EFCoreExistsById.cs
+++ b/src/SimpleSoft.Database.EFCore/EFCoreExistsById.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -14,22 +15,20 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity<TId>
         where TId : IEquatable<TId>
     {
-        private readonly EFCoreContextContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreExistsById(
-            EFCoreContextContainer container
-        )
+        /// <param name="query"></param>
+        public EFCoreExistsById(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
         public async Task<bool> ExistsAsync(TId id, CancellationToken ct) => 
-            await _container.Query<TEntity>().AnyAsync(e => e.Id.Equals(id), ct);
+            await _query.AnyAsync(e => e.Id.Equals(id), ct);
     }
 
     /// <summary>
@@ -43,8 +42,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreExistsById(EFCoreContextContainer container) : base(container)
+        /// <param name="query"></param>
+        public EFCoreExistsById(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.EFCore/EFCoreReadByExternalId.cs
+++ b/src/SimpleSoft.Database.EFCore/EFCoreReadByExternalId.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -14,22 +15,20 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity, IHaveExternalId<TId>
         where TId : IEquatable<TId>
     {
-        private readonly EFCoreContextContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreReadByExternalId(
-            EFCoreContextContainer container
-        )
+        /// <param name="query"></param>
+        public EFCoreReadByExternalId(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
         public async Task<TEntity> ReadAsync(TId externalId, CancellationToken ct) =>
-            await _container.Query<TEntity>().SingleOrDefaultAsync(e => e.ExternalId.Equals(externalId), ct);
+            await _query.SingleOrDefaultAsync(e => e.ExternalId.Equals(externalId), ct);
     }
 
     /// <summary>
@@ -43,8 +42,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreReadByExternalId(EFCoreContextContainer container) : base(container)
+        /// <param name="query"></param>
+        public EFCoreReadByExternalId(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.EFCore/EFCoreReadByExternalIdRange.cs
+++ b/src/SimpleSoft.Database.EFCore/EFCoreReadByExternalIdRange.cs
@@ -17,17 +17,15 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity, IHaveExternalId<TId>
         where TId : IEquatable<TId>
     {
-        private readonly EFCoreContextContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreReadByExternalIdRange(
-            EFCoreContextContainer container
-        )
+        /// <param name="query"></param>
+        public EFCoreReadByExternalIdRange(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
@@ -35,7 +33,7 @@ namespace SimpleSoft.Database
         {
             if (externalIds == null) throw new ArgumentNullException(nameof(externalIds));
 
-            return await _container.Query<TEntity>().Where(e => externalIds.Contains(e.ExternalId)).ToListAsync(ct);
+            return await _query.Where(e => externalIds.Contains(e.ExternalId)).ToListAsync(ct);
         }
     }
 
@@ -50,8 +48,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreReadByExternalIdRange(EFCoreContextContainer container) : base(container)
+        /// <param name="query"></param>
+        public EFCoreReadByExternalIdRange(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.EFCore/EFCoreReadById.cs
+++ b/src/SimpleSoft.Database.EFCore/EFCoreReadById.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -14,22 +15,20 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity<TId>
         where TId : IEquatable<TId>
     {
-        private readonly EFCoreContextContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreReadById(
-            EFCoreContextContainer container
-        )
+        /// <param name="query"></param>
+        public EFCoreReadById(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
         public async Task<TEntity> ReadAsync(TId id, CancellationToken ct) =>
-            await _container.Query<TEntity>().SingleOrDefaultAsync(e => e.Id.Equals(id), ct);
+            await _query.SingleOrDefaultAsync(e => e.Id.Equals(id), ct);
     }
 
     /// <summary>
@@ -42,8 +41,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreReadById(EFCoreContextContainer container) : base(container)
+        /// <param name="query"></param>
+        public EFCoreReadById(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.EFCore/EFCoreReadByIdRange.cs
+++ b/src/SimpleSoft.Database.EFCore/EFCoreReadByIdRange.cs
@@ -17,17 +17,15 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity<TId>
         where TId : IEquatable<TId>
     {
-        private readonly EFCoreContextContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreReadByIdRange(
-            EFCoreContextContainer container
-        )
+        /// <param name="query"></param>
+        public EFCoreReadByIdRange(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
@@ -35,7 +33,7 @@ namespace SimpleSoft.Database
         {
             if (ids == null) throw new ArgumentNullException(nameof(ids));
 
-            return await _container.Query<TEntity>().Where(e => ids.Contains(e.Id)).ToListAsync(ct);
+            return await _query.Where(e => ids.Contains(e.Id)).ToListAsync(ct);
         }
     }
 
@@ -50,8 +48,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public EFCoreReadByIdRange(EFCoreContextContainer container) : base(container)
+        /// <param name="query"></param>
+        public EFCoreReadByIdRange(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.NH/NHExistsByExternalId.cs
+++ b/src/SimpleSoft.Database.NH/NHExistsByExternalId.cs
@@ -1,5 +1,6 @@
 ﻿using NHibernate.Linq;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,22 +15,20 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity, IHaveExternalId<TId>
         where TId : IEquatable<TId>
     {
-        private readonly NHSessionContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHExistsByExternalId(
-            NHSessionContainer container
-        )
+        /// <param name="query"></param>
+        public NHExistsByExternalId(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
         public async Task<bool> ExistsAsync(TId externalId, CancellationToken ct) =>
-            await _container.Query<TEntity>().AnyAsync(e => e.ExternalId.Equals(externalId), ct);
+            await _query.AnyAsync(e => e.ExternalId.Equals(externalId), ct);
     }
 
     /// <summary>
@@ -43,8 +42,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHExistsByExternalId(NHSessionContainer container) : base(container)
+        /// <param name="query"></param>
+        public NHExistsByExternalId(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.NH/NHExistsById.cs
+++ b/src/SimpleSoft.Database.NH/NHExistsById.cs
@@ -1,5 +1,6 @@
 ﻿using NHibernate.Linq;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,22 +15,20 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity<TId>
         where TId : IEquatable<TId>
     {
-        private readonly NHSessionContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHExistsById(
-            NHSessionContainer container
-        )
+        /// <param name="query"></param>
+        public NHExistsById(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
         public async Task<bool> ExistsAsync(TId id, CancellationToken ct) =>
-            await _container.Query<TEntity>().AnyAsync(e => e.Id.Equals(id), ct);
+            await _query.AnyAsync(e => e.Id.Equals(id), ct);
     }
 
     /// <summary>
@@ -43,8 +42,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHExistsById(NHSessionContainer container) : base(container)
+        /// <param name="query"></param>
+        public NHExistsById(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.NH/NHReadByExternalId.cs
+++ b/src/SimpleSoft.Database.NH/NHReadByExternalId.cs
@@ -1,5 +1,6 @@
 ﻿using NHibernate.Linq;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,22 +15,20 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity, IHaveExternalId<TId>
         where TId : IEquatable<TId>
     {
-        private readonly NHSessionContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHReadByExternalId(
-            NHSessionContainer container
-        )
+        /// <param name="query"></param>
+        public NHReadByExternalId(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
         public async Task<TEntity> ReadAsync(TId externalId, CancellationToken ct) =>
-            await _container.Query<TEntity>().SingleOrDefaultAsync(e => e.ExternalId.Equals(externalId), ct);
+            await _query.SingleOrDefaultAsync(e => e.ExternalId.Equals(externalId), ct);
     }
 
     /// <summary>
@@ -43,8 +42,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHReadByExternalId(NHSessionContainer container) : base(container)
+        /// <param name="query"></param>
+        public NHReadByExternalId(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.NH/NHReadByExternalIdRange.cs
+++ b/src/SimpleSoft.Database.NH/NHReadByExternalIdRange.cs
@@ -17,17 +17,15 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity, IHaveExternalId<TId>
         where TId : IEquatable<TId>
     {
-        private readonly NHSessionContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHReadByExternalIdRange(
-            NHSessionContainer container
-        )
+        /// <param name="query"></param>
+        public NHReadByExternalIdRange(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
@@ -35,7 +33,7 @@ namespace SimpleSoft.Database
         {
             if (externalIds == null) throw new ArgumentNullException(nameof(externalIds));
 
-            return await _container.Query<TEntity>().Where(e => externalIds.Contains(e.ExternalId)).ToListAsync(ct);
+            return await _query.Where(e => externalIds.Contains(e.ExternalId)).ToListAsync(ct);
         }
     }
 
@@ -50,8 +48,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHReadByExternalIdRange(NHSessionContainer container) : base(container)
+        /// <param name="query"></param>
+        public NHReadByExternalIdRange(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.NH/NHReadById.cs
+++ b/src/SimpleSoft.Database.NH/NHReadById.cs
@@ -1,5 +1,6 @@
 ﻿using NHibernate.Linq;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,22 +15,20 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity<TId>
         where TId : IEquatable<TId>
     {
-        private readonly NHSessionContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHReadById(
-            NHSessionContainer container
-        )
+        /// <param name="query"></param>
+        public NHReadById(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
         public async Task<TEntity> ReadAsync(TId id, CancellationToken ct) =>
-            await _container.Query<TEntity>().SingleOrDefaultAsync(e => e.Id.Equals(id), ct);
+            await _query.SingleOrDefaultAsync(e => e.Id.Equals(id), ct);
     }
 
     /// <summary>
@@ -42,8 +41,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHReadById(NHSessionContainer container) : base(container)
+        /// <param name="query"></param>
+        public NHReadById(IQueryable<TEntity> query) : base(query)
         {
 
         }

--- a/src/SimpleSoft.Database.NH/NHReadByIdRange.cs
+++ b/src/SimpleSoft.Database.NH/NHReadByIdRange.cs
@@ -17,17 +17,15 @@ namespace SimpleSoft.Database
         where TEntity : class, IEntity<TId>
         where TId : IEquatable<TId>
     {
-        private readonly NHSessionContainer _container;
+        private readonly IQueryable<TEntity> _query;
 
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHReadByIdRange(
-            NHSessionContainer container
-        )
+        /// <param name="query"></param>
+        public NHReadByIdRange(IQueryable<TEntity> query)
         {
-            _container = container;
+            _query = query;
         }
 
         /// <inheritdoc />
@@ -35,7 +33,7 @@ namespace SimpleSoft.Database
         {
             if (ids == null) throw new ArgumentNullException(nameof(ids));
 
-            return await _container.Query<TEntity>().Where(e => ids.Contains(e.Id)).ToListAsync(ct);
+            return await _query.Where(e => ids.Contains(e.Id)).ToListAsync(ct);
         }
     }
 
@@ -50,8 +48,8 @@ namespace SimpleSoft.Database
         /// <summary>
         /// Creates a new instance
         /// </summary>
-        /// <param name="container"></param>
-        public NHReadByIdRange(NHSessionContainer container) : base(container)
+        /// <param name="query"></param>
+        public NHReadByIdRange(IQueryable<TEntity> query) : base(query)
         {
 
         }


### PR DESCRIPTION
closes #21 